### PR TITLE
feat: add HttpResponse class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,6 +9,7 @@ SpaceAfterCStyleCast: true
 IndentAccessModifiers: false
 AccessModifierOffset: -4
 
+AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: InlineOnly
 BreakConstructorInitializers: BeforeColon
 PackConstructorInitializers: Never

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 webserv
 *.o
 *.d
+tester
+cgi_tester
+ubuntu_tester
+ubuntu_cgi_tester

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -1,0 +1,22 @@
+#include "HttpResponse.hpp"
+
+#include <sstream>
+
+std::string HttpResponse::to_string() const
+{
+    std::ostringstream out;
+    std::string reason;
+
+    switch (status) {
+    case 200: reason = "OK"; break;
+    case 404: reason = "Not Found"; break;
+    default: reason = "Unknown"; break;
+    }
+
+    out << "HTTP/1.1 " << status << "\r\n";
+    out << "Content-Type: " << content_type << "\r\n";
+    out << "Content-Length: " << body.size() << "\r\n";
+    out << "\r\n";
+    out << body;
+    return out.str();
+}

--- a/HttpResponse.hpp
+++ b/HttpResponse.hpp
@@ -1,0 +1,13 @@
+#ifndef HTTPRESPONSE_HPP_
+#define HTTPRESPONSE_HPP_
+
+#include <string>
+
+struct HttpResponse {
+    int status;
+    std::string content_type;
+    std::string body;
+    std::string to_string() const;
+};
+
+#endif // HTTPRESPONSE_HPP_

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ NAME = webserv
 CXX = clang++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -g3 -MMD -MP
 
-SRCS = main.cpp Server.cpp Socket.cpp Client.cpp
-HDRS = Server.hpp Socket.hpp Client.hpp
+SRCS = main.cpp Server.cpp Socket.cpp Client.cpp HttpResponse.cpp
+HDRS = Server.hpp Socket.hpp Client.hpp HttpResponse.hpp
 
 OBJS = $(SRCS:.cpp=.o)
 DEPS = $(OBJS:.o=.d)

--- a/Server.cpp
+++ b/Server.cpp
@@ -2,6 +2,8 @@
 
 #include "Server.hpp"
 
+#include "HttpResponse.hpp"
+
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <stdlib.h>
@@ -94,13 +96,10 @@ void Server::accept_connection()
 
 void Server::send_response(int event_fd)
 {
-    const char* response = "HTTP/1.1 200 OK\r\n"
-                           "Content-Length: 14\r\n"
-                           "Content-Type: text/plain\r\n"
-                           "\r\n"
-                           "Hello, client!\n";
+    HttpResponse res = {200, "text/plain", "Hello, client!"};
+    std::string raw = res.to_string();
 
-    send(event_fd, response, strlen(response), 0);
+    send(event_fd, raw.c_str(), raw.size(), 0);
     epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, event_fd, NULL);
     delete clients_[event_fd];
     clients_.erase(event_fd);


### PR DESCRIPTION
Just added a new HttpResponse class to easily mock HTTP responses @StokesAsselborn 

Example:
```c++
HttpResponse res = {200, "text/plain", "Hello, client!"};
```

Result
```
HTTP/1.1 200 OK\r\n
Content-Length: 14\r\n
Content-Type: text/plain\r\n
\r\n
Hello, client!
```