### PR TITLE
Feature/add handler to client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SRCS      = $(addprefix $(SRC_DIR)/, \
             core/signals.cpp \
             core/signals.hpp \
             handler/handler.cpp \
-			handler/hanlder.hpp \
+			handler/handler.hpp \
 			handler/get_handler.cpp \
 			handler/get_handler.hpp \
 			http/http_request.hpp \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ SRCS      = $(addprefix $(SRC_DIR)/, \
             core/server.hpp \
             core/signals.cpp \
             core/signals.hpp \
-            http/http_request.hpp \
+            handler/handler.cpp \
+			handler/hanlder.hpp \
+			handler/get_handler.cpp \
+			handler/get_handler.hpp \
+			http/http_request.hpp \
             http/http_response.cpp \
             http/http_response.hpp \
             router/router.cpp \

--- a/files/42.txt
+++ b/files/42.txt
@@ -1,1 +1,1 @@
-some secret data
+some secret data that should never be displayed in the browser

--- a/src/core/client.cpp
+++ b/src/core/client.cpp
@@ -53,6 +53,9 @@ Client::~Client()
     if (fd_ != -1) {
         close(fd_);
     }
+    if (handler_) {
+        delete (handler_);
+    }
 }
 
 void Client::set_nonblocking()

--- a/src/core/client.cpp
+++ b/src/core/client.cpp
@@ -5,11 +5,23 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+void Client::set_handler(Handler* handler)
+{
+    handler_ = handler;
+}
+
+// send buffer, if buffer empty then cal
+void Client::on_write()
+{
+}
+
 Client::Client(int fd, const sockaddr_in& addr)
     : fd_(fd),
       addr_(addr),
       prev_(NULL),
-      next_(NULL)
+      next_(NULL),
+      handler_(NULL)
+
 {
     set_nonblocking();
 }

--- a/src/core/client.cpp
+++ b/src/core/client.cpp
@@ -11,8 +11,30 @@ void Client::set_handler(Handler* handler)
 }
 
 // send buffer, if buffer empty then cal
-void Client::on_write()
+void Client::on_writable()
 {
+    if (handler_ && !handler_->is_done())
+        handler_->on_writable(this);
+}
+
+bool Client::handler_is_done()
+{
+    return (handler_->is_done());
+}
+
+void Client::flush_send_bufffer()
+{
+    if (send_buffer_.empty())
+        return;
+    // sending buffer
+    ssize_t n = send(fd_, send_buffer_.c_str(), send_buffer_.size(), 0);
+    // erase buffer
+    if (n > 0) {
+        send_buffer_.erase(0, send_buffer_.size());
+    }
+    else if (n == 0) {
+        // mark the client as closed
+    }
 }
 
 Client::Client(int fd, const sockaddr_in& addr)

--- a/src/core/client.cpp
+++ b/src/core/client.cpp
@@ -5,6 +5,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <iostream>
+
 void Client::set_handler(Handler* handler)
 {
     handler_ = handler;
@@ -46,6 +48,7 @@ Client::Client(int fd, const sockaddr_in& addr)
 
 {
     set_nonblocking();
+    std::cout << "Client constructor called" << std::endl;
 }
 
 Client::~Client()
@@ -56,6 +59,7 @@ Client::~Client()
     if (handler_) {
         delete (handler_);
     }
+    std::cout << "Client destructor called" << std::endl;
 }
 
 void Client::set_nonblocking()

--- a/src/core/client.hpp
+++ b/src/core/client.hpp
@@ -1,6 +1,7 @@
 #ifndef CORE_CLIENT_HPP_
 #define CORE_CLIENT_HPP_
 
+#include "../handler/handler.hpp"
 #include "http/http_request.hpp"
 #include "http/http_response.hpp"
 
@@ -19,9 +20,9 @@ public:
     void set_next(Client* conn) { next_ = conn; }
     void set_prev(Client* conn) { prev_ = conn; }
 
+    // getters
     int fd() const { return fd_; }
     const sockaddr_in& addr() const { return addr_; }
-
     const HttpRequest& req() const { return req_; }
     HttpResponse& res() { return res_; }
     std::string& recv_buffer() { return recv_buffer_; }
@@ -29,6 +30,11 @@ public:
 
     Client* next() { return next_; }
     Client* prev() { return prev_; }
+
+    void set_handler(Handler* handler);
+    void on_write();
+    void append_buffer(const std::string& data);
+    // void on_read();     TO DO(IBOUKH)
 
 private:
     Client();
@@ -44,6 +50,7 @@ private:
     std::string send_buffer_;
     Client* prev_;
     Client* next_;
+    Handler* handler_;
 };
 
 #endif // CORE_CLIENT_HPP_

--- a/src/core/client.hpp
+++ b/src/core/client.hpp
@@ -1,13 +1,15 @@
 #ifndef CORE_CLIENT_HPP_
 #define CORE_CLIENT_HPP_
 
-#include "../handler/handler.hpp"
+#include "handler/handler.hpp"
 #include "http/http_request.hpp"
 #include "http/http_response.hpp"
 
 #include <netinet/in.h>
 
 #include <string>
+
+class Handler;
 
 class Client {
 public:
@@ -27,14 +29,17 @@ public:
     HttpResponse& res() { return res_; }
     std::string& recv_buffer() { return recv_buffer_; }
     std::string& send_buffer() { return send_buffer_; }
-
     Client* next() { return next_; }
     Client* prev() { return prev_; }
 
+    // setters
     void set_handler(Handler* handler);
-    void on_write();
-    void append_buffer(const std::string& data);
-    // void on_read();     TO DO(IBOUKH)
+
+    // methods
+    void on_writable();
+    bool handler_is_done();
+    void flush_send_bufffer();
+    // void on_read(); ?     TO DO(IBOUKH)
 
 private:
     Client();

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -210,7 +210,7 @@ void Server::receive_request(Client* conn)
     // for dev, mimic a http request and call the routing function
     HttpRequest req;
     req.method = "GET";
-    req.path = "/files/norm42.txt";
+    req.path = "/files/42.txt";
 
     conn->set_request(req);
 

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -210,7 +210,7 @@ void Server::receive_request(Client* conn)
     // for dev, mimic a http request and call the routing function
     HttpRequest req;
     req.method = "GET";
-    req.path = "/files/42.txt";
+    req.path = "/files/norm42.txt";
 
     conn->set_request(req);
 
@@ -228,8 +228,17 @@ void Server::receive_request(Client* conn)
 
 void Server::send_response(Client* conn)
 {
-    if (!conn->send_buffer().empty()) {
-        // send
+    conn->flush_send_bufffer();
+
+    if (conn->send_buffer().empty()) {
+        conn->on_writable();
+    }
+    if (conn->handler_is_done() && conn->send_buffer().empty()) {
+        // assuming HTTP/1.0 for testing
+        if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, conn->fd(), NULL) == -1) {
+            throw UnrecoverableError("epoll_ctl", errno);
+        }
+        remove_connection(conn);
     }
 }
 

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -231,13 +231,16 @@ void Server::send_response(Client* conn)
     conn->flush_send_bufffer();
 
     if (conn->send_buffer().empty()) {
+        std::cout << "calling on writable" << std::endl;
         conn->on_writable();
     }
-    if (conn->handler_is_done() && conn->send_buffer().empty()) {
+    // if (conn->handler_is_done() && conn->send_buffer().empty()) {
+    if (conn->handler_is_done()) {
         // assuming HTTP/1.0 for testing
         if (epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, conn->fd(), NULL) == -1) {
             throw UnrecoverableError("epoll_ctl", errno);
         }
+        std::cout << "attempting to remove the connection" << std::endl;
         remove_connection(conn);
     }
 }

--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -221,10 +221,19 @@ void Server::receive_request(Client* conn)
         return; // bad request
     if (req.method == "GET") {
         // add handler to conn
-        // conn.handler = New GetHandler(full_path);
+        GetHandler* handler = new GetHandler(conn, full_path);
+        conn->set_handler(handler);
     }
 }
 
+void Server::send_response(Client* conn)
+{
+    if (!conn->send_buffer().empty()) {
+        // send
+    }
+}
+
+/*
 void Server::send_response(Client* conn)
 {
     int client_fd = conn->fd();
@@ -238,4 +247,4 @@ void Server::send_response(Client* conn)
     }
 
     remove_connection(conn);
-}
+}*/

--- a/src/handler/get_handler.cpp
+++ b/src/handler/get_handler.cpp
@@ -23,7 +23,7 @@ void GetHandler::on_writable(Client* conn)
     }
     else if (errno != EAGAIN && errno != EINTR) {
         done_ = true;
-        ::close(fd_);
+        close(fd_);
         // conn->res().set_error(500, "Read Error");
     }
 }

--- a/src/handler/get_handler.cpp
+++ b/src/handler/get_handler.cpp
@@ -2,6 +2,7 @@
 
 #include "sys/stat.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -70,8 +71,7 @@ GetHandler::GetHandler(Client* conn, const std::string& path)
     : Handler(path),
       fd_(-1),
       size_(0),
-      done_(false),
-      path_(path)
+      done_(false)
 {
     struct stat file_stat;
 

--- a/src/handler/get_handler.cpp
+++ b/src/handler/get_handler.cpp
@@ -5,6 +5,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <sstream>
+
 #define BUFFER_SIZE 4096
 
 // check if file isOpen else continue stream to message_buffer
@@ -12,36 +14,80 @@ void GetHandler::on_writable(Client* conn)
 {
     char buff[BUFFER_SIZE];
     int bytes_read = read(fd_, buff, BUFFER_SIZE);
-    buff[bytes_read] = '\0';
     if (bytes_read > 0) {
-        (conn->send_buffer()).append(buff);
+        (conn->send_buffer()).append(buff, bytes_read);
     }
     else if (bytes_read == 0) {
         done_ = true;
+        close(fd_);
     }
-    else {
-        // error handling
+    else if (errno != EAGAIN && errno != EINTR) {
+        done_ = true;
+        ::close(fd_);
+        // conn->res().set_error(500, "Read Error");
     }
 }
 
-GetHandler::GetHandler(const Client* conn, const std::string& path)
-    : Handler(path)
+std::string GetHandler::derive_file_type()
+{
+    size_t pos = path_.rfind(".");
+    if (pos == std::string::npos)
+        return ("application/octet-stream");
+    std::string ext = path_.substr(pos + 1);
+    if (ext == "html" || ext == "htm")
+        return "text/html";
+    else if (ext == "txt")
+        return "text/plain";
+    else if (ext == "css")
+        return "text/css";
+    else if (ext == "js")
+        return "application/javascript";
+    else if (ext == "jpg" || ext == "jpeg")
+        return "image/jpeg";
+    else if (ext == "png")
+        return "image/png";
+    else if (ext == "gif")
+        return "image/gif";
+    else if (ext == "ico")
+        return "image/x-icon";
+    else
+        return "application/octet-stream";
+}
+
+void GetHandler::write_headers(Client* conn)
+{
+    HttpResponse& res = conn->res();
+    res.status = 200;
+    res.headers["Content-Type"] = derive_file_type();
+    std::ostringstream oss;
+    oss << size_;
+    res.headers["Content-Length"] = oss.str();
+    res.headers["Connection"] = "keep-alive";
+    (conn->send_buffer()).append(res.to_string());
+}
+
+GetHandler::GetHandler(Client* conn, const std::string& path)
+    : Handler(path),
+      fd_(-1),
+      size_(0),
+      done_(false),
+      path_(path)
 {
     struct stat file_stat;
 
-    if (stat(path.c_str(), &file_stat) != 0) {
+    if (stat(path.c_str(), &file_stat) != 0 || !S_ISREG(file_stat.st_mode)) {
         // conn.set_status(kNotFound);
         //  how to stop then here ?
-    }
-    if (!S_ISREG(file_stat.st_mode)) {
-        // not a file -> how to handle ?
-        // conn.set_status(kBadRequest);
+        return;
     }
     fd_ = open(path.c_str(), O_RDONLY);
     if (fd_ == -1) {
         // file could not be opened
         // conn.set_status(kInternalServerError);
+        return;
     }
+    size_ = file_stat.st_size;
+    write_headers(conn);
 }
 
 GetHandler::~GetHandler()

--- a/src/handler/get_handler.cpp
+++ b/src/handler/get_handler.cpp
@@ -70,8 +70,8 @@ void GetHandler::write_headers(Client* conn)
 GetHandler::GetHandler(Client* conn, const std::string& path)
     : Handler(path),
       fd_(-1),
-      size_(0),
-      done_(false)
+      size_(0)
+// done_(false)
 {
     struct stat file_stat;
 

--- a/src/handler/get_handler.cpp
+++ b/src/handler/get_handler.cpp
@@ -14,7 +14,7 @@ void GetHandler::on_writable(Client* conn)
     int bytes_read = read(fd_, buff, BUFFER_SIZE);
     buff[bytes_read] = '\0';
     if (bytes_read > 0) {
-        conn->append_send_buffer(buff);
+        (conn->send_buffer()).append(buff);
     }
     else if (bytes_read == 0) {
         done_ = true;

--- a/src/handler/get_handler.hpp
+++ b/src/handler/get_handler.hpp
@@ -9,16 +9,19 @@
 
 class GetHandler : public Handler {
 public:
-    explicit GetHandler(const Client* conn, const std::string& path);
+    explicit GetHandler(Client* conn, const std::string& path);
     ~GetHandler();
 
     GetHandler(const GetHandler& other);
     GetHandler& operator=(const GetHandler& other);
 
     void on_writable(Client* conn);
+    void write_headers(Client* conn);
+    std::string derive_file_type();
 
 private:
     GetHandler();
+    std::string path_;
     int fd_;
     off_t size_;
     bool done_;

--- a/src/handler/get_handler.hpp
+++ b/src/handler/get_handler.hpp
@@ -23,7 +23,7 @@ private:
     GetHandler();
     int fd_;
     off_t size_;
-    bool done_;
+    // bool done_;
 };
 
 #endif

--- a/src/handler/get_handler.hpp
+++ b/src/handler/get_handler.hpp
@@ -21,7 +21,6 @@ public:
 
 private:
     GetHandler();
-    std::string path_;
     int fd_;
     off_t size_;
     bool done_;

--- a/src/handler/handler.cpp
+++ b/src/handler/handler.cpp
@@ -7,7 +7,7 @@ bool Handler::is_done()
 }
 
 Handler::Handler(const std::string& path)
-    : kPath(path),
+    : path_(path),
       done_(false)
 {
 }

--- a/src/handler/handler.hpp
+++ b/src/handler/handler.hpp
@@ -1,9 +1,11 @@
 #ifndef HANDLER_HANDLER_HPP_
 #define HANDLER_HANDLER_HPP_
 
-#include "../core/client.hpp"
+#include "core/client.hpp"
 
 #include <string>
+
+class Client;
 
 class Handler {
 public:
@@ -17,7 +19,7 @@ public:
     bool is_done();
 
 protected:
-    const std::string kPath;
+    std::string path_;
 
 private:
     Handler();

--- a/src/handler/handler.hpp
+++ b/src/handler/handler.hpp
@@ -20,10 +20,10 @@ public:
 
 protected:
     std::string path_;
+    bool done_;
 
 private:
     Handler();
-    bool done_;
 };
 
 #endif


### PR DESCRIPTION
This pull request covers 3 parts : 

1)  Server.cpp : updating the member function send_response() to interact with the Handler through the client. On EPOLLOUT, the send_response function will flush the send_buffer of the client (e.g. send the data in the send_buffer and erase it to clear the buffer) and then ask the Handler if there is more data to be send. If yes, the Handler will write the next chunk to the send_buffer of the client. For the moment, the server will keep sending until all data is sent and then close the connection. No keep alive is implemented yet, but this is an easy fix as one would simple need to check the request and set the event to EPOLLIN again after finishing sending the data.

2) Client.hpp / Client.cpp : adding mainly two methods. First, a method to flush the send_buffer (e.g. send data and then erase the buffer). Second, the method on_writable() that requests the GetHandler to provide the next chunk of data if any.

3) GetHandler.hpp /GetHandler.cpp : The constructor is in charge of opening the file and writing the headers to the HttpResponse struct. Then the to_string function is used to write these headers to the send_buffer. During the next epoll iteration, the client request to the Handler to provide the next chunk of data. This is when the body is written to the send_buffer.

There are plenty of points to be checked / improved : leaking fd, memory leaks, error handling, etc.